### PR TITLE
Fix linked list allocation and search logic

### DIFF
--- a/Data Structures and Algorithms/Linked_List.c
+++ b/Data Structures and Algorithms/Linked_List.c
@@ -64,7 +64,7 @@ void beginsert()
 {
     struct node *ptr;
     int item;
-    ptr = (struct node *)malloc(sizeof(struct node *));
+    ptr = (struct node *)malloc(sizeof(struct node));
     if (ptr == NULL)
     {
         printf("\nOVERFLOW");
@@ -210,7 +210,7 @@ void random_delete()
 void search()
 {
     struct node *ptr;
-    int item, i = 0, flag;
+    int item, i = 0, flag = 1;
     ptr = head;
     if (ptr == NULL)
     {
@@ -226,10 +226,7 @@ void search()
             {
                 printf("item found at location %d ", i + 1);
                 flag = 0;
-            }
-            else
-            {
-                flag = 1;
+                break;
             }
             i++;
             ptr = ptr->next;


### PR DESCRIPTION
## Summary
- allocate correct size for new nodes in `beginsert`
- prevent false negatives in `search` by initializing flag and exiting loop when found

## Testing
- `gcc -Wall -Wextra -std=c11 'Data Structures and Algorithms/Linked_List.c' -o /tmp/linkedlist`
- `printf "1\n10\n7\n10\n9\n" | /tmp/linkedlist`


------
https://chatgpt.com/codex/tasks/task_e_688f3a7e4078832ba8475dc31e765c75